### PR TITLE
Ensure input depth maps + mask tensors are on the same device as predicted depth maps

### DIFF
--- a/runners/completion_net_inference_runner.py
+++ b/runners/completion_net_inference_runner.py
@@ -91,7 +91,7 @@ def depth_completion_net_inference_runner(args):
     with torch.no_grad():
         pred_depth_maps, _ = completion_net(depth_maps_tensor.to(device), mask_tensor.to(device), shape_tensor.to(device))
     pred_depth_maps = pred_depth_maps.to(device)
-    pred_depth_maps = (1 - mask_tensor) * depth_maps_tensor + mask_tensor * pred_depth_maps
+    pred_depth_maps = (1 - mask_tensor.to(device)) * depth_maps_tensor.to(device) + mask_tensor.to(device) * pred_depth_maps
     
     # 4. Visualization
     # 4.1 Depth maps


### PR DESCRIPTION
This small fix ensures that the input depth maps and mask tensors are on the same device as the predicted depth maps. Without this, you will receive the following runtime error:

```
    pred_depth_maps = (1 - mask_tensor) * depth_maps_tensor + mask_tensor * pred_depth_maps
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and CPU!
```