### PR TITLE
Fix runtime args for iterative warping runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,177 @@
+# Created by https://www.toptal.com/developers/gitignore/api/python
+# Edit at https://www.toptal.com/developers/gitignore?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+*.pyc
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
+
+# End of https://www.toptal.com/developers/gitignore/api/python

--- a/app.py
+++ b/app.py
@@ -177,7 +177,7 @@ def run_stablev2v(
             img_list = sorted(os.listdir(file_path))
             image = cv2.imread(os.path.join(file_path, img_list[1]))
             height, width, _ = image.shape
-            fourcc = cv2.VideoWriter_fourcc('M', 'P', '4', 'V')
+            fourcc = cv2.VideoWriter_fourcc('m', 'p', '4', 'v')
             videowriter = cv2.VideoWriter(output, fourcc, fps, (width, height))
             for img in img_list:
                 path = os.path.join(file_path, img)
@@ -188,7 +188,7 @@ def run_stablev2v(
         
         # Return the generated gif path
         result_path = os.path.join(args.outdir, 'generator_outputs', 'output_frames')
-        image_to_video(result_path, os.path.join(args.outdir, 'generator_outputs', 'output_video.mp4'))
+        image_to_video(result_path, os.path.join(args.outdir, 'generator_outputs', 'output_video.mp4'), args.output_fps)
         return os.path.join(args.outdir, 'generator_outputs', 'output_video.mp4')
 
 

--- a/runners/iterative_warping/run_warp_with_averaged_flow.py
+++ b/runners/iterative_warping/run_warp_with_averaged_flow.py
@@ -51,7 +51,7 @@ def iterative_warp_with_averaged_flow(args):
     # Load optical flows
     optical_flow_paths = sorted(os.listdir(args.optical_flow))
     optical_flows = []
-    for optical_flow_path in optical_flow_paths[:16]:
+    for optical_flow_path in optical_flow_paths[:args.n_sample_frames]:
         optical_flow = np.load(os.path.join(args.optical_flow, optical_flow_path))
         optical_flow = torch.from_numpy(optical_flow)
         optical_flows.append(optical_flow)
@@ -66,11 +66,11 @@ def iterative_warp_with_averaged_flow(args):
     init_mask[init_mask <= 0.5] = 0
 
     # Create dilated mask
-    kernel = np.ones((11, 11), np.uint8)  # You can adjust the kernel size as needed
-    dilated_mask = cv2.dilate(init_mask.squeeze().cpu().numpy(), kernel, iterations=9)
+    kernel = np.ones((args.kernel_size, args.kernel_size), np.uint8)  # You can adjust the kernel size as needed
+    dilated_mask = cv2.dilate(init_mask.squeeze().cpu().numpy(), kernel, iterations=args.dilation_iteration)
     
     # Erode the dilated mask
-    erode_kernel = np.ones((11, 11), np.uint8)  # Adjust kernel size as needed
+    erode_kernel = np.ones((args.kernel_size, args.kernel_size), np.uint8)  # Adjust kernel size as needed
     dilated_mask = cv2.erode(dilated_mask, erode_kernel, iterations=6)
 
     dilated_mask = torch.from_numpy(dilated_mask).unsqueeze(0).unsqueeze(0)


### PR DESCRIPTION
This PR has the following fixes:

1. Added .gitignore to ignore common Python extensions and files that should not be included in commits
2. `cv2.VideoWriter_fourcc` has a warning recommending lowercasing the `mp4v` code, which is now done.
3. The `app.py` did not take the output FPS parameter from the Gradio app when writing the output video, which is now fixed.
4. The iterative warping runner had some hyperparameters set without using the `args`. This would result in shape errors for the tensors if the number of output frames is not 16. Also, the mask size of the dilation masks, and the kernel size do not change when varying those parameters in the Gradio app.
